### PR TITLE
Add a timeout

### DIFF
--- a/Sources/WebPush/WebPushManager.swift
+++ b/Sources/WebPush/WebPushManager.swift
@@ -371,7 +371,7 @@ public actor WebPushManager: Sendable {
         request.body = .bytes(ByteBuffer(bytes: requestContent))
         
         /// Send the request to the push endpoint.
-        let response = try await httpClient.execute(request, deadline: .now(), logger: logger)
+        let response = try await httpClient.execute(request, deadline: .now() + .seconds(2), logger: logger)
         
         /// Check the response and determine if the subscription should be removed from our records, or if the notification should just be skipped.
         switch response.status {


### PR DESCRIPTION
Without the timeout the request expires immediately and results in the `HTTPClientError.deadlineExceeded`.

I'm not sure why the async methods of AsyncHTTPClient don't allow a `nil` deadline like other methods (to use the overall client default).

This patch makes it work, but maybe there should be a more general way to configure the timeout.