### PR TITLE
VAPID Definition Refactor

### DIFF
--- a/Sources/WebPush/Subscriber.swift
+++ b/Sources/WebPush/Subscriber.swift
@@ -23,9 +23,9 @@ public protocol SubscriberProtocol: Sendable {
     
     /// The preferred VAPID Key ID to use, if available.
     ///
-    /// If unknown, use the key set to ``VoluntaryApplicationServerIdentification/Configuration/primaryKey``, but be aware that this may be different from the key originally used at time of subscription, and if it is, push messages will be rejected.
+    /// If unknown, use the key set to ``VAPID/Configuration/primaryKey``, but be aware that this may be different from the key originally used at time of subscription, and if it is, push messages will be rejected.
     ///
-    /// - Important: It is highly recommended to store the VAPID Key ID used at time of registration with the subscriber, and always supply the key itself to the manager. If you are phasing out the key and don't want new subscribers registered against it, store the key in ``VoluntaryApplicationServerIdentification/Configuration/deprecatedKeys``, otherwise store it in ``VoluntaryApplicationServerIdentification/Configuration/keys``.
+    /// - Important: It is highly recommended to store the VAPID Key ID used at time of registration with the subscriber, and always supply the key itself to the manager. If you are phasing out the key and don't want new subscribers registered against it, store the key in ``VAPID/Configuration/deprecatedKeys``, otherwise store it in ``VAPID/Configuration/keys``.
     var vapidKeyID: VAPID.Key.ID { get }
 }
 

--- a/Sources/WebPush/VAPID/VAPID.swift
+++ b/Sources/WebPush/VAPID/VAPID.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-public typealias VAPID = VoluntaryApplicationServerIdentification
+public typealias VoluntaryApplicationServerIdentification = VAPID
 
 /// A set of types for Voluntary Application Server Identification, also known as VAPID.
 ///
-/// - SeeAlso: [RFC 8292](https://datatracker.ietf.org/doc/html/rfc8292)
-public enum VoluntaryApplicationServerIdentification: Sendable {}
+/// - SeeAlso: [RFC 8292 Voluntary Application Server Identification (VAPID) for Web Push](https://datatracker.ietf.org/doc/html/rfc8292)
+public enum VAPID: Sendable {}

--- a/Sources/WebPush/VAPID/VAPIDConfiguration.swift
+++ b/Sources/WebPush/VAPID/VAPIDConfiguration.swift
@@ -31,7 +31,7 @@ extension VoluntaryApplicationServerIdentification {
         /// The VAPID key that identifies the push service to subscribers.
         ///
         /// If not provided, a key from ``keys`` will be used instead.
-        /// - SeeAlso: ``VoluntaryApplicationServerIdentification/Configuration``
+        /// - SeeAlso: ``VAPID/Configuration``
         public private(set) var primaryKey: Key?
         
         /// The set of valid keys to choose from when identifying the applications erver to new registrations.

--- a/Sources/WebPush/VAPID/VAPIDKey.swift
+++ b/Sources/WebPush/VAPID/VAPIDKey.swift
@@ -12,7 +12,7 @@ import Foundation
 extension VoluntaryApplicationServerIdentification {
     /// Represents the application server's identification key that is used to confirm to a push service that the server connecting to it is the same one that was subscribed to.
     ///
-    /// When sharing with the browser, ``VoluntaryApplicationServerIdentification/Key/ID`` can be used.
+    /// When sharing with the browser, ``VAPID/Key/ID`` can be used.
     public struct Key: Sendable {
         private var privateKey: P256.Signing.PrivateKey
         
@@ -62,7 +62,7 @@ extension VAPID.Key: Codable {
 }
 
 extension VAPID.Key: Identifiable {
-    /// The identifier for a private ``VoluntaryApplicationServerIdentification/Key``'s public key.
+    /// The identifier for a private ``VAPID/Key``'s public key.
     ///
     /// This value can be shared as is with a subscription registration as the `applicationServerKey` key in JavaScript.
     ///


### PR DESCRIPTION
Swapped the definitions for VAPID and its fully qualified name so the fully qualified one is the type alias.