### PR TITLE
Mocked Configuration Rename

### DIFF
--- a/Sources/WebPushTesting/VAPIDConfiguration+Testing.swift
+++ b/Sources/WebPushTesting/VAPIDConfiguration+Testing.swift
@@ -12,5 +12,5 @@ import WebPush
 
 extension VAPID.Configuration {
     /// A mocked configuration useful when testing with the library, since the mocked manager doesn't make use of it anyways.
-    public static let mocked = VAPID.Configuration(key: .mockedKey1, contactInformation: .email("test@example.com"))
+    public static let mockedConfiguration = VAPID.Configuration(key: .mockedKey1, contactInformation: .email("test@example.com"))
 }

--- a/Sources/WebPushTesting/WebPushManager+Testing.swift
+++ b/Sources/WebPushTesting/WebPushManager+Testing.swift
@@ -23,7 +23,7 @@ extension WebPushManager {
     ///   - messageHandler: A handler to receive messages or throw errors.
     /// - Returns: A new manager suitable for mocking.
     public static func makeMockedManager(
-        vapidConfiguration: VAPID.Configuration = .mocked,
+        vapidConfiguration: VAPID.Configuration = .mockedConfiguration,
         // TODO: Add networkConfiguration for proxy, number of simultaneous pushes, etc…
         logger: Logger? = nil,
         messageHandler: @escaping @Sendable (

--- a/Tests/WebPushTests/WebPushManagerTests.swift
+++ b/Tests/WebPushTests/WebPushManagerTests.swift
@@ -90,7 +90,7 @@ struct WebPushManagerTests {
         
         /// This is needed to cover the `uniquingKeysWith` safety call completely.
         @Test func managerConstructsAValidKeyLookupFromQuestionableConfiguration() async throws {
-            var configuration = VAPID.Configuration.mocked
+            var configuration = VAPID.Configuration.mockedConfiguration
             configuration.unsafeUpdateKeys(primaryKey: .mockedKey1, keys: [.mockedKey1], deprecatedKeys: [.mockedKey1])
             let manager = WebPushManager(vapidConfiguration: configuration)
             #expect(await manager.vapidKeyLookup == [.mockedKeyID1 : .mockedKey1])
@@ -105,7 +105,7 @@ struct WebPushManagerTests {
     
     @Suite("VAPID Key Retrieval") struct VAPIDKeyRetrieval {
         @Test func retrievesPrimaryKey() async {
-            let manager = WebPushManager(vapidConfiguration: .mocked)
+            let manager = WebPushManager(vapidConfiguration: .mockedConfiguration)
             #expect(manager.nextVAPIDKeyID == .mockedKeyID1)
             await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
@@ -116,7 +116,7 @@ struct WebPushManagerTests {
         }
         
         @Test func alwaysRetrievesPrimaryKey() async throws {
-            var configuration = VAPID.Configuration.mocked
+            var configuration = VAPID.Configuration.mockedConfiguration
             try configuration.updateKeys(primaryKey: .mockedKey1, keys: [.mockedKey2], deprecatedKeys: [.mockedKey3])
             let manager = WebPushManager(vapidConfiguration: configuration)
             for _ in 0..<100_000 {
@@ -131,7 +131,7 @@ struct WebPushManagerTests {
         }
         
         @Test func retrievesFallbackKeys() async throws {
-            var configuration = VAPID.Configuration.mocked
+            var configuration = VAPID.Configuration.mockedConfiguration
             try configuration.updateKeys(primaryKey: nil, keys: [.mockedKey1, .mockedKey2])
             let manager = WebPushManager(vapidConfiguration: configuration)
             var keyCounts: [VAPID.Key.ID : Int] = [:]
@@ -148,7 +148,7 @@ struct WebPushManagerTests {
         }
         
         @Test func neverRetrievesDeprecatedKeys() async throws {
-            var configuration = VAPID.Configuration.mocked
+            var configuration = VAPID.Configuration.mockedConfiguration
             try configuration.updateKeys(primaryKey: nil, keys: [.mockedKey1, .mockedKey2], deprecatedKeys: [.mockedKey3])
             let manager = WebPushManager(vapidConfiguration: configuration)
             for _ in 0..<100_000 {
@@ -163,7 +163,7 @@ struct WebPushManagerTests {
         }
         
         @Test func keyStatus() async throws {
-            var configuration = VAPID.Configuration.mocked
+            var configuration = VAPID.Configuration.mockedConfiguration
             try configuration.updateKeys(primaryKey: .mockedKey1, keys: [.mockedKey2], deprecatedKeys: [.mockedKey3])
             let manager = WebPushManager(vapidConfiguration: configuration)
             #expect(manager.keyStatus(for: .mockedKeyID1) == .valid)


### PR DESCRIPTION
Renamed `VAPID.Configuration.mocked` to `VAPID.Configuration.mockedConfiguration`.