### PR TITLE
Better Logging

### DIFF
--- a/Sources/WebPush/WebPushManager.swift
+++ b/Sources/WebPush/WebPushManager.swift
@@ -456,7 +456,7 @@ public actor WebPushManager: Sendable {
 
 extension WebPushManager: Service {
     public func run() async throws {
-        logger.info("Starting up WebPushManager")
+        logger.debug("Starting up WebPushManager")
         guard !didShutdown else {
             assertionFailure("The manager was already shutdown and cannot be started.")
             logger.error("The manager was already shutdown and cannot be started. Run your application server in debug mode to catch this.")
@@ -465,7 +465,7 @@ extension WebPushManager: Service {
         try await withTaskCancellationOrGracefulShutdownHandler {
             try await gracefulShutdown()
         } onCancelOrGracefulShutdown: { [logger, executor] in
-            logger.info("Shutting down WebPushManager")
+            logger.debug("Shutting down WebPushManager")
             do {
                 if case let .httpClient(httpClient) = executor {
                     try httpClient.syncShutdown()

--- a/Sources/WebPush/WebPushManager.swift
+++ b/Sources/WebPush/WebPushManager.swift
@@ -651,7 +651,7 @@ extension WebPushManager {
         
         /// A message originally sent via ``WebPushManager/send(string:to:expiration:urgency:)``
         case string(String)
-        /// A message originally sent via ``WebPushManager/send(json:to:expiration:urgency:)
+        /// A message originally sent via ``WebPushManager/send(json:to:expiration:urgency:)``
         case json(any Encodable&Sendable)
         
         /// The message, encoded as data.

--- a/Sources/WebPushTesting/WebPushManager+Testing.swift
+++ b/Sources/WebPushTesting/WebPushManager+Testing.swift
@@ -25,7 +25,7 @@ extension WebPushManager {
     public static func makeMockedManager(
         vapidConfiguration: VAPID.Configuration = .mockedConfiguration,
         // TODO: Add networkConfiguration for proxy, number of simultaneous pushes, etc…
-        logger: Logger? = nil,
+        backgroundActivityLogger: Logger? = .defaultWebPushPrintLogger,
         messageHandler: @escaping @Sendable (
             _ message: Message,
             _ subscriber: Subscriber,
@@ -33,11 +33,11 @@ extension WebPushManager {
             _ urgency: Urgency
         ) async throws -> Void
     ) -> WebPushManager {
-        let logger = Logger(label: "MockWebPushManager", factory: { logger?.handler ?? PrintLogHandler(label: $0, metadataProvider: $1) })
+        let backgroundActivityLogger = backgroundActivityLogger ?? .defaultWebPushNoOpLogger
         
         return WebPushManager(
             vapidConfiguration: vapidConfiguration,
-            logger: logger,
+            backgroundActivityLogger: backgroundActivityLogger,
             executor: .handler(messageHandler)
         )
     }

--- a/Tests/WebPushTests/WebPushManagerTests.swift
+++ b/Tests/WebPushTests/WebPushManagerTests.swift
@@ -33,7 +33,7 @@ struct WebPushManagerTests {
             let logger = Logger(label: "ServiceLogger", factory: { PrintLogHandler(label: $0, metadataProvider: $1) })
             let manager = WebPushManager(
                 vapidConfiguration: .makeTesting(),
-                logger: logger
+                backgroundActivityLogger: logger
             )
             await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
@@ -217,7 +217,7 @@ struct WebPushManagerTests {
                 
                 let manager = WebPushManager(
                     vapidConfiguration: vapidConfiguration,
-                    logger: Logger(label: "WebPushManagerTests", factory: { PrintLogHandler(label: $0, metadataProvider: $1) }),
+                    backgroundActivityLogger: Logger(label: "WebPushManagerTests", factory: { PrintLogHandler(label: $0, metadataProvider: $1) }),
                     executor: .httpClient(MockHTTPClient({ request in
                         try validateAuthotizationHeader(
                             request: request,
@@ -264,7 +264,7 @@ struct WebPushManagerTests {
                 
                 let manager = WebPushManager(
                     vapidConfiguration: vapidConfiguration,
-                    logger: Logger(label: "WebPushManagerTests", factory: { PrintLogHandler(label: $0, metadataProvider: $1) }),
+                    backgroundActivityLogger: Logger(label: "WebPushManagerTests", factory: { PrintLogHandler(label: $0, metadataProvider: $1) }),
                     executor: .httpClient(MockHTTPClient({ request in
                         try validateAuthotizationHeader(
                             request: request,
@@ -311,7 +311,7 @@ struct WebPushManagerTests {
                 
                 let manager = WebPushManager(
                     vapidConfiguration: vapidConfiguration,
-                    logger: Logger(label: "WebPushManagerTests", factory: { PrintLogHandler(label: $0, metadataProvider: $1) }),
+                    backgroundActivityLogger: Logger(label: "WebPushManagerTests", factory: { PrintLogHandler(label: $0, metadataProvider: $1) }),
                     executor: .httpClient(MockHTTPClient({ request in
                         try validateAuthotizationHeader(
                             request: request,
@@ -358,7 +358,7 @@ struct WebPushManagerTests {
                 
                 let manager = WebPushManager(
                     vapidConfiguration: vapidConfiguration,
-                    logger: Logger(label: "WebPushManagerTests", factory: { PrintLogHandler(label: $0, metadataProvider: $1) }),
+                    backgroundActivityLogger: Logger(label: "WebPushManagerTests", factory: { PrintLogHandler(label: $0, metadataProvider: $1) }),
                     executor: .httpClient(MockHTTPClient({ request in
                         requestWasMade()
                         return HTTPClientResponse(status: .notFound)
@@ -387,7 +387,7 @@ struct WebPushManagerTests {
                 
                 let manager = WebPushManager(
                     vapidConfiguration: vapidConfiguration,
-                    logger: Logger(label: "WebPushManagerTests", factory: { PrintLogHandler(label: $0, metadataProvider: $1) }),
+                    backgroundActivityLogger: Logger(label: "WebPushManagerTests", factory: { PrintLogHandler(label: $0, metadataProvider: $1) }),
                     executor: .httpClient(MockHTTPClient({ request in
                         requestWasMade()
                         return HTTPClientResponse(status: .gone)
@@ -416,7 +416,7 @@ struct WebPushManagerTests {
                 
                 let manager = WebPushManager(
                     vapidConfiguration: vapidConfiguration,
-                    logger: Logger(label: "WebPushManagerTests", factory: { PrintLogHandler(label: $0, metadataProvider: $1) }),
+                    backgroundActivityLogger: Logger(label: "WebPushManagerTests", factory: { PrintLogHandler(label: $0, metadataProvider: $1) }),
                     executor: .httpClient(MockHTTPClient({ request in
                         requestWasMade()
                         return HTTPClientResponse(status: .internalServerError)


### PR DESCRIPTION
- Updated the main logger logic to use a fallback logger rather than a child logger, based on feedback from [slack](https://swift-open-source.slack.com/archives/CN4BCMN8Z/p1734512151763979)
- Renamed `WebPushManager`'s logger to `backgroundActivityLogger` to match `AsyncHTTPClient`'s use of a similar logger.
- Added `logger`s to the send methods.
- Added much more comprehensive logging metadata.
- Fixed the logging level of service logs to one appropriate for libraries.
- Fixed some missing backticks on documentation.