### PR TITLE
MessageTooLarge, more Mocks

### DIFF
--- a/Sources/WebPush/Errors/MessageTooLargeError.swift
+++ b/Sources/WebPush/Errors/MessageTooLargeError.swift
@@ -1,0 +1,20 @@
+//
+//  MessageTooLargeError.swift
+//  swift-webpush
+//
+//  Created by Dimitri Bouniol on 2024-12-13.
+//  Copyright © 2024 Mochi Development, Inc. All rights reserved.
+//
+
+import Foundation
+
+/// The message was too large, and could not be delivered to the push service.
+///
+/// - SeeAlso: ``WebPushManager/maximumMessageSize``
+public struct MessageTooLargeError: LocalizedError, Hashable {
+    public init() {}
+    
+    public var errorDescription: String? {
+        "The message was too large, and could not be delivered to the push service."
+    }
+}

--- a/Sources/WebPush/WebPushManager.swift
+++ b/Sources/WebPush/WebPushManager.swift
@@ -681,6 +681,8 @@ extension WebPushManager.Urgency: Codable {
 
 extension WebPushManager {
     /// An internal type representing a push message, accessible when using ``/WebPushTesting``.
+    ///
+    /// - Warning: Never switch on the message type, as values may be added to it over time.
     public enum _Message: Sendable, CustomStringConvertible {
         /// A message originally sent via ``WebPushManager/send(data:to:expiration:urgency:)``
         case data(Data)
@@ -705,6 +707,20 @@ extension WebPushManager {
                     return try encoder.encode(json)
                 }
             }
+        }
+        
+        /// The string value from a ``string(_:)`` message.
+        public var string: String? {
+            guard case let .string(string) = self
+            else { return nil }
+            return string
+        }
+        
+        /// The json value from a ``json(_:)`` message.
+        public func json<JSON: Encodable&Sendable>(as: JSON.Type = JSON.self) -> JSON? {
+            guard case let .json(json) = self
+            else { return nil }
+            return json as? JSON
         }
         
         public var description: String {

--- a/Sources/WebPush/WebPushManager.swift
+++ b/Sources/WebPush/WebPushManager.swift
@@ -494,7 +494,9 @@ public actor WebPushManager: Sendable {
         switch response.status {
         case .created: break
         case .notFound, .gone: throw BadSubscriberError()
-        // TODO: 413 payload too large - log.error and throw error
+        case .payloadTooLarge:
+            logger.error("The encrypted payload was too large and was rejected by the push service.")
+            throw MessageTooLargeError()
         // TODO: 429 too many requests, 500 internal server error, 503 server shutting down - check config and perform a retry after a delay?
         default: throw HTTPError(response: response)
         }

--- a/Sources/WebPushTesting/Subscriber+Testing.swift
+++ b/Sources/WebPushTesting/Subscriber+Testing.swift
@@ -1,0 +1,53 @@
+//
+//  Subscriber+Testing.swift
+//  swift-webpush
+//
+//  Created by Dimitri Bouniol on 2024-12-20.
+//  Copyright © 2024 Mochi Development, Inc. All rights reserved.
+//
+
+@preconcurrency import Crypto
+import Foundation
+import WebPush
+
+extension Subscriber {
+    /// A mocked subscriber to send messages to.
+    public static let mockedSubscriber = Subscriber(
+        endpoint: URL(string: "https://example.com/subscriber")!,
+        userAgentKeyMaterial: .mockedKeyMaterial,
+        vapidKeyID: .mockedKeyID1
+    )
+    
+    /// Make a mocked subscriber with a unique private key and salt.
+    static func makeMockedSubscriber(endpoint: URL = URL(string: "https://example.com/subscriber")!) -> (subscriber: Subscriber, privateKey: P256.KeyAgreement.PrivateKey) {
+        let subscriberPrivateKey = P256.KeyAgreement.PrivateKey(compactRepresentable: false)
+        var authenticationSecret: [UInt8] = Array(repeating: 0, count: 16)
+        for index in authenticationSecret.indices { authenticationSecret[index] = .random(in: .min ... .max) }
+        
+        let subscriber = Subscriber(
+            endpoint: endpoint,
+            userAgentKeyMaterial: UserAgentKeyMaterial(publicKey: subscriberPrivateKey.publicKey, authenticationSecret: Data(authenticationSecret)),
+            vapidKeyID: .mockedKeyID1
+        )
+        
+        return (subscriber, subscriberPrivateKey)
+    }
+}
+
+extension SubscriberProtocol where Self == Subscriber {
+    /// A mocked subscriber to send messages to.
+    public static func mockedSubscriber() -> Subscriber {
+        .mockedSubscriber
+    }
+}
+
+extension UserAgentKeyMaterial {
+    /// The private key component of ``mockedKeyMaterial``.
+    public static let mockedKeyMaterialPrivateKey = try! P256.KeyAgreement.PrivateKey(rawRepresentation: Data(base64Encoded: "BS2nTTf5wAdVvi5Om3AjSmlsCpz91XgK+uCLaIJ0T/M=")!)
+    
+    /// A mocked user-agent-key material to attach to a subscriber.
+    public static let mockedKeyMaterial = try! UserAgentKeyMaterial(
+        publicKey: "BMXVxJELqTqIqMka5N8ujvW6RXI9zo_xr5BQ6XGDkrsukNVPyKRMEEfzvQGeUdeZaWAaAs2pzyv1aoHEXYMtj1M",
+        authenticationSecret: "IzODAQZN6BbGvmm7vWQJXg"
+    )
+}

--- a/Sources/WebPushTesting/WebPushManager+Testing.swift
+++ b/Sources/WebPushTesting/WebPushManager+Testing.swift
@@ -11,6 +11,7 @@ import WebPush
 
 extension WebPushManager {
     /// A push message in its original form, either ``/Foundation/Data``, ``/Swift/String``, or ``/Foundation/Encodable``.
+    /// - Warning: Never switch on the message type, as values may be added to it over time.
     public typealias Message = _Message
     
     /// Create a mocked web push manager.

--- a/Tests/WebPushTests/WebPushManagerTests.swift
+++ b/Tests/WebPushTests/WebPushManagerTests.swift
@@ -482,4 +482,44 @@ struct WebPushManagerTests {
             #expect(try JSONDecoder().decode(WebPushManager.Expiration.self, from: Data("60".utf8)) == .minutes(1))
         }
     }
+    
+    @Suite struct Urgency {
+        @Test func comparison() {
+            #expect(WebPushManager.Urgency(rawValue: "invalid") < WebPushManager.Urgency.veryLow)
+            #expect(WebPushManager.Urgency(rawValue: "invalid") < WebPushManager.Urgency.low)
+            #expect(WebPushManager.Urgency(rawValue: "invalid") < WebPushManager.Urgency.normal)
+            #expect(WebPushManager.Urgency(rawValue: "invalid") < WebPushManager.Urgency.high)
+            
+            #expect(WebPushManager.Urgency.veryLow < WebPushManager.Urgency.low)
+            #expect(WebPushManager.Urgency.veryLow < WebPushManager.Urgency.normal)
+            #expect(WebPushManager.Urgency.veryLow < WebPushManager.Urgency.high)
+            
+            #expect(WebPushManager.Urgency.low < WebPushManager.Urgency.normal)
+            #expect(WebPushManager.Urgency.low < WebPushManager.Urgency.high)
+            
+            #expect(WebPushManager.Urgency.normal < WebPushManager.Urgency.high)
+        }
+        
+        @Test func stringEncoding() {
+            #expect("\(WebPushManager.Urgency(rawValue: "future-value"))" == "future-value")
+            #expect("\(WebPushManager.Urgency.veryLow)" == "very-low")
+            #expect("\(WebPushManager.Urgency.low)" == "low")
+            #expect("\(WebPushManager.Urgency.normal)" == "normal")
+            #expect("\(WebPushManager.Urgency.high)" == "high")
+        }
+        
+        @Test func coding() throws {
+            #expect(String(decoding: try JSONEncoder().encode(WebPushManager.Urgency(rawValue: "future-value")), as: UTF8.self) == "\"future-value\"")
+            #expect(String(decoding: try JSONEncoder().encode(WebPushManager.Urgency.veryLow), as: UTF8.self) == "\"very-low\"")
+            #expect(String(decoding: try JSONEncoder().encode(WebPushManager.Urgency.low), as: UTF8.self) == "\"low\"")
+            #expect(String(decoding: try JSONEncoder().encode(WebPushManager.Urgency.normal), as: UTF8.self) == "\"normal\"")
+            #expect(String(decoding: try JSONEncoder().encode(WebPushManager.Urgency.high), as: UTF8.self) == "\"high\"")
+            
+            #expect(try JSONDecoder().decode(WebPushManager.Urgency.self, from: Data("\"future-value\"".utf8)) == .init(rawValue: "future-value"))
+            #expect(try JSONDecoder().decode(WebPushManager.Urgency.self, from: Data("\"very-low\"".utf8)) == .veryLow)
+            #expect(try JSONDecoder().decode(WebPushManager.Urgency.self, from: Data("\"low\"".utf8)) == .low)
+            #expect(try JSONDecoder().decode(WebPushManager.Urgency.self, from: Data("\"normal\"".utf8)) == .normal)
+            #expect(try JSONDecoder().decode(WebPushManager.Urgency.self, from: Data("\"high\"".utf8)) == .high)
+        }
+    }
 }


### PR DESCRIPTION
Added a new error for push service rejections due to large messages (`MessageTooLargeError`), and added a variety of new mock methods to the Testing library for `Subscriber`s.