### PR TITLE
JSON Packing Efficiency

### DIFF
--- a/Sources/WebPush/WebPushManager.swift
+++ b/Sources/WebPush/WebPushManager.swift
@@ -1078,6 +1078,7 @@ extension WebPushManager {
                 case .json(let json):
                     let encoder = JSONEncoder()
                     encoder.dateEncodingStrategy = .millisecondsSince1970
+                    encoder.outputFormatting = [.withoutEscapingSlashes]
                     return try encoder.encode(json)
                 }
             }


### PR DESCRIPTION
Improved payload size slightly when sending JSON by omitting escaping slashes (`\/`), which are technically only needed within script tags.