### PR TITLE
Normalize Key IDs

### DIFF
--- a/Sources/WebPush/Helpers/DataProtocol+Base64URLCoding.swift
+++ b/Sources/WebPush/Helpers/DataProtocol+Base64URLCoding.swift
@@ -19,7 +19,15 @@ extension DataProtocol {
     func base64URLEncodedString() -> String {
         Data(self)
             .base64EncodedString()
-            .replacingOccurrences(of: "+", with: "-")
+            .transformToBase64URLEncoding()
+    }
+}
+
+extension String {
+    /// Transform a regular Base64 encoded string to a Base64URL encoded one.
+    @usableFromInline
+    func transformToBase64URLEncoding() -> String {
+        self.replacingOccurrences(of: "+", with: "-")
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
     }

--- a/Sources/WebPush/VAPID/VAPIDKey.swift
+++ b/Sources/WebPush/VAPID/VAPIDKey.swift
@@ -86,7 +86,7 @@ extension VAPID.Key: Identifiable {
         
         public init(from decoder: any Decoder) throws {
             let container = try decoder.singleValueContainer()
-            self.rawValue = try container.decode(String.self)
+            self.rawValue = try container.decode(String.self).transformToBase64URLEncoding()
         }
         
         public func encode(to encoder: any Encoder) throws {

--- a/Tests/WebPushTests/VAPIDKeyTests.swift
+++ b/Tests/WebPushTests/VAPIDKeyTests.swift
@@ -101,6 +101,7 @@ import WebPushTesting
         
         @Test func decoding() throws {
             #expect(try JSONDecoder().decode(VAPID.Key.ID.self, from: Data("\"BLf3RZAljlexEovBgfZgFTjcEVUKBDr3lIH8quJioMdX4FweRdId_P72h613ptxtU-qSAyW3Tbt_3WgwGhOUxrs\"".utf8)) == .mockedKeyID1)
+            #expect(try JSONDecoder().decode(VAPID.Key.ID.self, from: Data("\"BLf3RZAljlexEovBgfZgFTjcEVUKBDr3lIH8quJioMdX4FweRdId/P72h613ptxtU+qSAyW3Tbt/3WgwGhOUxrs=\"".utf8)) == .mockedKeyID1)
         }
     }
 }


### PR DESCRIPTION
Fixed an issue where Base64-encoded key IDs would fail lookups against the known set of configured keys.